### PR TITLE
Default to IL jurisdiction

### DIFF
--- a/docassemble/ILAOEfile/data/questions/efile-account-interview.yml
+++ b/docassemble/ILAOEfile/data/questions/efile-account-interview.yml
@@ -15,7 +15,6 @@ code: |
 metadata:
   title: eFileIL Account
   short title: efileIL
-  comment: This program helps you tell the court and the other parties that you are participating in a court case.
 ---
 default screen parts:
   logo: |
@@ -52,6 +51,9 @@ data: !!omap
 variable name: account_registration_choices
 data: !!omap
   - INDIVIDUAL: Self-represented user
+---
+code: |
+  jurisdiction_id = 'illinois'
 ---
 id: unauth-register-done
 question: |

--- a/docassemble/ILAOEfile/data/questions/shared-basic-questions.yml
+++ b/docassemble/ILAOEfile/data/questions/shared-basic-questions.yml
@@ -274,6 +274,7 @@ question: |
   Terms of use
 subquestion: |
   This program does not provide legal advice. It does not take the place of advice from a lawyer.
+
   Using this program does not create an attorney-client relationship between you and Illinois Legal Aid Online or its employees.
 
   ${ collapse_template(get_legal_help) }  

--- a/docassemble/ILAOEfile/data/questions/toga_payments_interview.yml
+++ b/docassemble/ILAOEfile/data/questions/toga_payments_interview.yml
@@ -10,6 +10,9 @@ metadata:
   comment: This program helps you tell the court and the other parties that you are participating in a court case.
 ---
 code: |
+  jurisdiction_id = 'illinois'
+---
+code: |
   interview_shorter_title = "Payment methods"
   ilao_easy_form_url = "https://www.illinoislegalaid.org/"
   ilao_easy_form_title = "Payment methods"


### PR DESCRIPTION
There are [some changes coming in EFSPIntegration](https://github.com/SuffolkLITLab/docassemble-EFSPIntegration/pull/229#issue-1887961043) that require this interview to specifically say that it's in Illinois.

I checked and things still work when you visit the efile account from the Appearance interview, which is how the vast majority of the users will visit it; you'd have to know the exact URL to go to otherwise. But this is a good backup to have.